### PR TITLE
make sure swoole debugger is built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM php:8.0.18-cli-alpine3.15 as compile
 
-ARG DEBUG=false
-ENV DEBUG=$DEBUG
-
 ENV PHP_REDIS_VERSION=5.3.7 \
     PHP_MONGODB_VERSION=1.13.0 \
     PHP_SWOOLE_VERSION=v4.8.10 \
@@ -50,16 +47,14 @@ RUN \
   cd ..
 
 ## Swoole Debugger setup
-RUN if [ "$DEBUG" == "true" ]; then \
-    cd /tmp && \
+RUN cd /tmp && \
     apk add boost-dev && \
     git clone --depth 1 https://github.com/swoole/yasd && \
     cd yasd && \
     phpize && \
     ./configure && \
     make && make install && \
-    cd ..;\
-  fi
+    cd ..;
 
 ## Imagick Extension
 FROM compile AS imagick

--- a/tests.yaml
+++ b/tests.yaml
@@ -5,6 +5,9 @@ fileExistenceTests:
   - name: 'Check swoole extension'
     path: /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so
     shouldExist: true
+  - name: 'Check swoole Debugger extension'
+    path: /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yasd.so
+    shouldExist: true
   - name: 'Check redis extension'
     path: /usr/local/lib/php/extensions/no-debug-non-zts-20200930/redis.so
     shouldExist: true


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- As we are not using `DEBUG` arg for this base image, the swoole debugger was never built, this change makes sure swoole debugger is always built and copied to final image

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)