### PR TITLE
Remove duplicate certbot and fix missing rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,7 +168,7 @@ RUN \
   curl-dev \
   && apk add --no-cache \
   libstdc++ \
-  certbot \
+  rsync \
   brotli-dev \
   yaml-dev \
   imagemagick \


### PR DESCRIPTION
## What does this PR do?

rsync is used by a volume-sync task so it needs to be installed in the image.

## Test Plan

Manually ran `apk update` command in the container.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes