### PR TITLE
Fix missing lz4 libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN \
   g++ \
   git \
   zlib-dev \
-  brotli-dev \
   openssl-dev \
   yaml-dev \
   imagemagick \
@@ -167,6 +166,7 @@ RUN \
   libstdc++ \
   rsync \
   brotli-dev \
+  lz4-dev \
   yaml-dev \
   imagemagick \
   imagemagick-dev \


### PR DESCRIPTION
## What does this PR do?

lz4-dev is required to be used in the final image.

## Test Plan

Manually confirmed adding the package makes the warning go away.

![image](https://user-images.githubusercontent.com/1477010/229209524-d81bfef0-8f77-478b-abbc-555c43155362.png)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes