### PR TITLE
Feat: CURL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,7 @@ RUN \
   certbot \
   docker-cli \
   libgomp \
+  git \
   && docker-php-ext-install sockets opcache pdo_mysql pdo_pgsql \
   && apk del .deps \
   && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN \
   libmaxminddb-dev \
   zstd-dev \
   brotli-dev \
-  lz4-dev
+  lz4-dev \
+  curl-dev
 
 RUN docker-php-ext-install sockets
 
@@ -47,7 +48,7 @@ RUN \
   git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git && \
   cd swoole-src && \
   phpize && \
-  ./configure --enable-sockets --enable-http2 --enable-openssl && \
+  ./configure --enable-sockets --enable-http2 --enable-openssl --enable-swoole-curl && \
   make && make install && \
   cd ..
 


### PR DESCRIPTION
CURL is needed as Appwrite complains with error `swoole_curl_setopt(): option[234] is not supported` without those changes

Git is needed for templates & starters. Adding git fixes error during deployment build `Unable to clone code repository: sh: git: not found`