### PR TITLE
Install PHP intl extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ RUN \
   docker-cli \
   libgomp \
   git \
-  && docker-php-ext-install sockets pdo_mysql pdo_pgsql \
+  && docker-php-ext-install sockets pdo_mysql pdo_pgsql intl \
   && apk del .deps \
   && rm -rf /var/cache/apk/*
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -134,3 +134,8 @@ commandTests:
       - ".*brotli.*"
       - ".*lz4.*"
       - ".*snappy.*"
+  - name: 'PHP intl'
+    command: "php"
+    args: ["-r", 'print(\Normalizer::FORM_D);']
+    expectedOutput:
+      - "4"


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The extension is required by the SDK generator. Without it, the SDK generator would throw an error like:

```
    Class Normalizer not found
```

## Test Plan

Manually installed the extension and then was able to run the SDK generator:

<img width="987" alt="image" src="https://github.com/appwrite/docker-base/assets/1477010/4e54a7e1-9cf5-43c4-832b-673f94c0edef">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes