### PR TITLE
chore: bump base image php version for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE="php:8.3.17-cli-alpine3.20"
+ARG BASEIMAGE="php:8.3.19-cli-alpine3.20"
 
 FROM $BASEIMAGE AS compile
 


### PR DESCRIPTION
For both base image dependency and php version security issues, references:

- https://www.php.net/releases/8_3_19.php
- https://hub.docker.com/layers/library/php/8.3.17-cli-alpine3.20/images/sha256-a587eaad09c7529d1c89b4963998c7f641ad2293d41d26b133ca6b7bb575f6a2