### PR TITLE
Update php and alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE="php:8.3.17-cli-alpine3.20"
+ARG BASEIMAGE="php:8.3.24-cli-alpine3.22"
 
 FROM $BASEIMAGE AS compile
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -12,11 +12,11 @@ commandTests:
   - name: 'Certbot command'
     command: "certbot"
     args: ["--version"]
-    expectedOutput: ["certbot 2.*"]
+    expectedOutput: ["certbot 4.*"]
   - name: 'Docker command'
     command: "docker"
     args: ["--version"]
-    expectedOutput: ["Docker version 26.*"]
+    expectedOutput: ["Docker version 28.*"]
   - name: 'PHP info'
     command: "php"
     args: ["-m"]


### PR DESCRIPTION
Update Dockerfile to use PHP 8.3.24 and Alpine 3.22 for latest patches and improved stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab8067ce-6c1d-4747-9ed6-467faf1aa6cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab8067ce-6c1d-4747-9ed6-467faf1aa6cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

