### PR TITLE
feat: add support for webp in imagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,7 @@ RUN \
   libjxl-dev \
   libavif \
   libheif \
+  libwebp \
   imagemagick-heic \
   zlib-dev \
   libpng-dev \

--- a/tests.yaml
+++ b/tests.yaml
@@ -17,7 +17,7 @@ commandTests:
     command: "docker"
     args: ["--version"]
     expectedOutput: ["Docker version 28.*"]
-  - name: 'PHP info'
+  - name: 'PHP modules'
     command: "php"
     args: ["-m"]
     expectedOutput:
@@ -71,6 +71,11 @@ commandTests:
       - yaml
       - zlib
       - zstd
+  - name: 'ImageMagick supported formats'
+    command: "php"
+    args: ["-i"]
+    expectedOutput:
+      - "ImageMagick supported formats .*WEBP.*"
   - name: 'PHP intl'
     command: "php"
     args: ["-r", 'print(\Normalizer::FORM_D);']


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because libwebp was not installed, imagemagick-dev wasn't installed with webp support. To ensure downstream dependencies to support webp, libwebp must be installed along with imagemagick-dev

## Test Plan

Updated tests to check for WEBP as supported format

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/10699
- https://github.com/appwrite/docker-base/pull/51

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added WebP image format support library to runtime dependencies to enable WebP handling.

* **Tests**
  * Updated system verification tests to check for WebP support and adjusted PHP-related test naming to reflect module validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->