### PR TITLE
fix: postgressql-dev ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,7 @@ RUN \
   gcc \
   g++ \
   curl-dev \
+  postgresql-dev \
   && apk add --no-cache \
   libstdc++ \
   rsync \
@@ -204,7 +205,7 @@ RUN \
   libgomp \
   git \
   zip \
-  postgresql-dev \
+  libpq \
   && docker-php-ext-install sockets pdo_mysql pdo_pgsql intl \
   && apk del .deps \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
reduces image size significantly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration to reduce runtime dependencies while maintaining PostgreSQL client connectivity. Build-time artifacts are now properly separated from runtime requirements, resulting in a leaner final image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->