### PR TITLE
FIX GitHub action triggering for building image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -43,7 +43,7 @@ jobs:
           docker image push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{matrix.arch}}
 
   manifest_build_and_push_on_feature:
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
     needs: build_and_push
     runs-on: ubuntu-24.04
     steps:
@@ -64,8 +64,8 @@ jobs:
         run: |
             docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 
-  manifest_build_and_push_on_main:
-    if: github.ref == 'refs/heads/main'
+  manifest_build_and_push_on_tag:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: build_and_push
     runs-on: ubuntu-24.04
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Version 1.1.1
+
+### Fix
+
+* .github/workflows/build-and-push.yml manifest_build_and_push_on_feature no longer wrongs on tag creation
+* .github/workflows/build-and-push.yml manifest_build_and_push_on_tag now correctly builds on tag creation
+
 ## Version 1.1.0
 
 ### Add
@@ -26,13 +33,13 @@
 * PHP version bumped to 8.5
 * Refactored multi-arch build process to prevent cross-arch builds requiring long wait times
 
-### Fixes
+### Fix
 
 * README.md usage instructions more detailed
 
 ### Miscellaneous
 
-### Removed
+### Remove
 
 * Build tools from final stage of Dockerfile
 * GitHub action to Setup QEMU as GitHub now provides native ARM runners

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Fix
 
-* .github/workflows/build-and-push.yml manifest_build_and_push_on_feature no longer wrongs on tag creation
+* .github/workflows/build-and-push.yml manifest_build_and_push_on_feature no longer triggers on tag creation
 * .github/workflows/build-and-push.yml manifest_build_and_push_on_tag now correctly builds on tag creation
 
 ## Version 1.1.0


### PR DESCRIPTION
## What does this PR do?

## Version 1.1.1

### Fix

* .github/workflows/build-and-push.yml manifest_build_and_push_on_feature no longer wrongs on tag creation
* .github/workflows/build-and-push.yml manifest_build_and_push_on_tag now correctly builds on tag creation

## Test Plan

Merge to main, create tag via release process.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI/CD pipeline configuration to properly build and push Docker manifests exclusively when code is tagged, preventing inadvertent builds during feature branch development and updates to the main branch.
  * Updated release documentation to note version 1.1.1 fixes to the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->