### PR TITLE
Restore git binary in final runtime image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
 * container-structure-test for `git` command
 
+### Change
+
+* `tests.yaml` PHP assertion bumped to 8.5.5 (upstream `phpswoole/swoole:php8.5-alpine` update)
+* `tests.yaml` Swoole assertion bumped to 6.2.1
+
 ## Version 1.2.0
 
 ### Add

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Version 1.2.1
+
+### Fix
+
+* Restore `git` in final image — unintentionally dropped from runtime apk install in 1.2.0; required by VCS-dependent services
+
+### Add
+
+* container-structure-test for `git` command
+
 ## Version 1.2.0
 
 ### Add

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     freetype \
     docker-cli \
     docker-cli-compose \
+    git \
     icu-libs \
     imagemagick \
     imagemagick-heic \

--- a/tests.yaml
+++ b/tests.yaml
@@ -92,7 +92,7 @@ commandTests:
     command: "php"
     args: ["-v"]
     expectedOutput:
-      - "PHP 8.5.4 (cli)*"
+      - "PHP 8.5.5 (cli)*"
   - name: 'ImageMagick supported formats'
     command: "php"
     args: ["-i"]
@@ -107,7 +107,7 @@ commandTests:
     command: "php"
     args: ["--re", "swoole"]
     expectedOutput:
-      - ".*version 6.2.0.*"
+      - ".*version 6.2.1.*"
   - name: 'ZIP'
     command: "zip"
     args: ["-v"]

--- a/tests.yaml
+++ b/tests.yaml
@@ -21,6 +21,10 @@ commandTests:
     command: "docker"
     args: ["compose", "version"]
     expectedOutput: ["Docker Compose version v.*"]
+  - name: 'Git command'
+    command: "git"
+    args: ["--version"]
+    expectedOutput: ["git version 2.*"]
   - name: 'PHP modules'
     command: "php"
     args: ["-m"]


### PR DESCRIPTION
## Summary

- Adds `git` back to the `apk add` list in the final stage of `Dockerfile`. It was dropped in #66 (1.2.0) during the size-reduction refactor.
- Adds a `container-structure-test` for `git --version` so a future regression is caught.
- Bumps `CHANGES.md` to 1.2.1.

## Why this matters

PR #66 removed several package names from the runtime `apk add` list: `git`, `rsync`, `zip`, `imagemagick`, `certbot`, `docker-cli`. Inspecting `appwrite/base:1.2.0` shows that everything **except** `git` is still present in the final filesystem — those binaries are provided by the upstream `phpswoole/swoole:php8.5-alpine` base image, so removing the duplicate apk line had no runtime effect. `git` is the exception: it was uniquely added by this repo back in `504b0ba` ("Install git for VCS service") and is not in the swoole base, so it actually disappeared from 1.2.0. Services that shell out to git (VCS sync etc.) would break on the new image.

## Test plan

- [ ] CI builds the image and `tests.yaml` passes, including the new `Git command` check
- [ ] Manually verify `git --version` works inside the published image after merge