### PR TITLE
Remove PHP opentelemetry extension to re-enable JIT on 8.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 1.2.2
+
+### Remove
+
+* PHP `opentelemetry` extension — its observer hooks override `zend_execute_ex` and disable opcache JIT on PHP 8.5
+
 ## Version 1.2.1
 
 ### Fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV \
     PHP_LZ4_VERSION="0.6.0" \
     PHP_MAXMINDDB_VERSION="v1.13.1" \
     PHP_MONGODB_VERSION="2.2.1" \
-    PHP_OPENTELEMETRY_VERSION="1.2.1" \
     PHP_PROTOBUF_VERSION="5.34.0" \
     PHP_REDIS_VERSION="6.3.0" \
     PHP_SCRYPT_VERSION="2.0.1" \
@@ -152,10 +151,6 @@ RUN git clone --depth 1 https://github.com/DomBlack/php-scrypt.git  \
 
 # PHP PECL installs (acceptable method)
 
-FROM compile AS opentelemetry
-RUN pecl install opentelemetry-${PHP_OPENTELEMETRY_VERSION} && \
-    strip $(php-config --extension-dir)/opentelemetry.so
-
 FROM compile AS protobuf
 RUN pecl install protobuf-${PHP_PROTOBUF_VERSION} && \
     strip $(php-config --extension-dir)/protobuf.so
@@ -227,7 +222,6 @@ COPY --from=imagick /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DA
 COPY --from=lz4 /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/lz4.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
 COPY --from=maxmind /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/maxminddb.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
 COPY --from=mongodb /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/mongodb.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
-COPY --from=opentelemetry /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/opentelemetry.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
 COPY --from=protobuf /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/protobuf.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
 COPY --from=redis /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
 COPY --from=scrypt /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/scrypt.so /usr/local/lib/php/extensions/no-debug-non-zts-$PHP_BUILD_DATE/
@@ -244,7 +238,6 @@ RUN docker-php-ext-enable \
   lz4 \
   maxminddb \
   mongodb \
-  opentelemetry \
   pdo_mysql \
   pdo_pgsql \
   protobuf \

--- a/tests.yaml
+++ b/tests.yaml
@@ -49,7 +49,6 @@ commandTests:
       - mbstring
       - mysqlnd
       - openssl
-      - opentelemetry
       - pcre
       - PDO
       - pdo_mysql


### PR DESCRIPTION
## Summary
- Remove the `opentelemetry` PECL extension from the default image. Its observer hooks override `zend_execute_ex`, which causes opcache to refuse to enable JIT on PHP 8.5.
- Drop the `opentelemetry` build stage, version env, COPY, and `docker-php-ext-enable` entry from the Dockerfile.
- Drop the `opentelemetry` assertion from `tests.yaml`.
- Add a 1.2.2 entry to CHANGES.md.

## Test plan
- [ ] `docker build --no-cache --tag appwrite/base:latest .` succeeds
- [ ] `container-structure-test test --config tests.yaml --image appwrite/base:latest` passes
- [ ] `docker run appwrite/base:latest php -m` no longer lists `opentelemetry`
- [ ] With `opcache.jit=tracing` + `opcache.jit_buffer_size>0`, `php --ri opcache` reports JIT enabled (no "JIT is incompatible with third party extensions that override zend_execute_ex" warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)