### PR TITLE
Pin Swoole base image to 6.2 and fix tag manifest workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -78,10 +78,10 @@ jobs:
       - name: Create manifest
         run: |
             docker manifest create \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }} \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
 
       - name: Push manifest
         run: |
-            docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+            docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="phpswoole/swoole:php8.5-alpine"
+ARG BASE_IMAGE="phpswoole/swoole:6.2-php8.5-alpine"
 ARG PHP_BUILD_DATE="20250925"
 
 FROM $BASE_IMAGE AS compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="phpswoole/swoole:php8.5-alpine@sha256:ba7d2d342ba0e3fef134098fcb95a9bc2de278e14ed5d775f683a412c3a66790"
+ARG BASE_IMAGE="phpswoole/swoole:6.2.0-php8.5-alpine"
 ARG PHP_BUILD_DATE="20250925"
 
 FROM $BASE_IMAGE AS compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="phpswoole/swoole:6.2-php8.5-alpine"
+ARG BASE_IMAGE="phpswoole/swoole:php8.5-alpine@sha256:ba7d2d342ba0e3fef134098fcb95a9bc2de278e14ed5d775f683a412c3a66790"
 ARG PHP_BUILD_DATE="20250925"
 
 FROM $BASE_IMAGE AS compile

--- a/tests.yaml
+++ b/tests.yaml
@@ -92,7 +92,7 @@ commandTests:
     command: "php"
     args: ["-v"]
     expectedOutput:
-      - "PHP 8\\.5\\.\\d+ \\(cli\\).*"
+      - "PHP 8.5.4 (cli)*"
   - name: 'ImageMagick supported formats'
     command: "php"
     args: ["-i"]
@@ -107,7 +107,7 @@ commandTests:
     command: "php"
     args: ["--re", "swoole"]
     expectedOutput:
-      - ".*version 6\\.2\\.\\d+.*"
+      - ".*version 6.2.0.*"
   - name: 'ZIP'
     command: "zip"
     args: ["-v"]

--- a/tests.yaml
+++ b/tests.yaml
@@ -107,7 +107,7 @@ commandTests:
     command: "php"
     args: ["--re", "swoole"]
     expectedOutput:
-      - ".*version 6.2.1.*"
+      - ".*version 6\\.2\\.\\d+.*"
   - name: 'ZIP'
     command: "zip"
     args: ["-v"]

--- a/tests.yaml
+++ b/tests.yaml
@@ -92,7 +92,7 @@ commandTests:
     command: "php"
     args: ["-v"]
     expectedOutput:
-      - "PHP 8.5.5 (cli)*"
+      - "PHP 8\\.5\\.\\d+ \\(cli\\).*"
   - name: 'ImageMagick supported formats'
     command: "php"
     args: ["-i"]


### PR DESCRIPTION
## Summary
- Pin base image from the nightly `phpswoole/swoole:php8.5-alpine` tag to the stable `phpswoole/swoole:6.2-php8.5-alpine` line for reproducible builds. Loosened the `tests.yaml` Swoole assertion to `6.2.\d+` so any patch in the 6.2 line passes.
- Fix `manifest_build_and_push_on_tag` in `.github/workflows/build-and-push.yml`: it referenced `github.event.release.tag_name`, which is empty when the workflow is triggered by a tag push (no GitHub Release). The job ran with an empty tag and `docker manifest create docker.io/appwrite/base:` failed with "invalid reference format" on the `1.2.2` tag. Switched to `github.ref_name`, which is populated for both `push`-on-tag and `release` events.

## Notes
- The branch name still says `swoole-io-uring` — that direction was abandoned; the upstream Swoole image doesn't ship an io_uring variant, and rather than maintain a custom Swoole rebuild we just pinned to the stable tag.
- To recover the missing `1.2.2` manifest, re-run the failed job after merge or push it manually from the existing per-arch images.

## Test plan
- [ ] Build and Push workflow passes on this PR
- [ ] Container Structure Test passes (Swoole 6.2.x assertion)
- [ ] After merge, push a test tag (or re-run `1.2.2`) to confirm the manifest job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)