### PR TITLE
Run apk upgrade in final image to patch musl and xz CVEs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## Version 1.3.1
+
+### Fix
+
+* Run `apk upgrade` in the final image to pull patched `musl` and `xz-libs` — resolves CVE-2025-26519 (musl `qsort` stack corruption), the musl `iconv` GB18030 DoS, and the `xz` index-decoding buffer overflow (CVE-2026-34743, fixed in `xz-libs` 5.8.3-r0). The compile stage already ran `apk upgrade`, but the runtime stage didn't, so the published image was shipping unpatched libs from the base.
+
+## Version 1.3.0
+
+### Change
+
+* Pin Swoole base image to `phpswoole/swoole:6.2.0-php8.5-alpine` (released 6.2.0, was previously tracking nightly `php8.5-alpine`) for reproducible builds
+* `tests.yaml` PHP assertion bumped to 8.5.4 and Swoole assertion pinned to 6.2.0 to match the pinned base
+
+### Fix
+
+* Manifest workflow tag reference — `manifest_build_and_push_on_tag` now uses `github.ref_name` instead of `github.event.release.tag_name`, which is empty on plain tag-push events and broke the `1.2.2` tag run with `docker manifest create: invalid reference format`
+
 ## Version 1.2.2
 
 ### Remove

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,6 +183,8 @@ LABEL php_build_date=$PHP_BUILD_DATE
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
   echo $TZ > /etc/timezone && \
+  apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     brotli \
     certbot \


### PR DESCRIPTION
## Summary

- Add `apk update && apk upgrade --no-cache` to the `final` stage so the runtime image picks up patched Alpine packages. The `compile` stage already does this, but the `final` stage didn't, so the published image shipped unpatched `musl`/`xz-libs` from the base.
- Resolves Trivy findings: CVE-2025-26519 (musl `qsort` stack corruption, High), musl `iconv` GB18030 DoS, and CVE-2026-34743 (`xz-libs` index-decoding buffer overflow, fixed in 5.8.3-r0).
- Back-fill the missing 1.3.0 changelog entry and add 1.3.1 for this fix.

## Verification

Built `--target final` locally and verified package versions:

```
musl-1.2.5-r23
musl-utils-1.2.5-r23
xz-5.8.3-r0
xz-libs-5.8.3-r0
```

All target CVEs now have fixed versions installed.

## Test plan

- [ ] CI build succeeds
- [ ] Trivy scan on the resulting image no longer reports the four CVEs (#19, #35, #51, #52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)