### PR TITLE
fix: restore apk upgrade to patch OS package CVEs in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV \
 
 RUN \
   apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     autoconf \
     automake \
@@ -214,6 +215,7 @@ LABEL base_image=$BASE_IMAGE
 LABEL maintainer="team@appwrite.io"
 
 RUN apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     brotli \
     c-ares \


### PR DESCRIPTION
## Problem

The current `appwrite/base:1.4.2` image ships **unpatched OS packages**, which surface as **315 open Trivy code-scanning alerts** in downstream images (e.g. `appwrite/appwrite` on `1.9.x`). Affected packages include `musl`, `openssl`/`libssl3`/`libcrypto3`, `zlib`, `libpng`, `libexpat`, `util-linux` (`libblkid`/`libmount`), `imagemagick*`, `rsync`, and `py3-cryptography`.

## Root cause

[#70](https://github.com/appwrite/docker-base/pull/70) added `apk upgrade` to both the compile and final stages specifically *"to patch musl and xz CVEs … the published image was shipping unpatched libs from the base."*

[#71](https://github.com/appwrite/docker-base/pull/71) (build swoole from source) then refactored the Dockerfile and **accidentally dropped both `apk upgrade` calls**. Since then the runtime image only runs `apk add`, so inherited base packages are never upgraded and the published image freezes whatever was baked into the base at build time.

## Fix

Restore `apk upgrade --no-cache` in the `compile` and `final` stages (one line each). On rebuild, the runtime image pulls the latest patched packages from the pinned Alpine repo.

## Verification

Ran the exact final-stage apk sequence against the pinned `php:8.5-alpine@sha256:3cfccf28…` digest. Every flagged package now resolves to a version that meets or exceeds the alert's fixed version:

| Package | Was | Fixed (alert) | After this PR |
|---|---|---|---|
| musl / musl-utils | 1.2.5-r21 | 1.2.5-r23 | **1.2.5-r23** |
| openssl / libssl3 / libcrypto3 | 3.5.5-r0 | 3.5.6-r0 | **3.5.6-r0** |
| zlib | 1.3.1-r2 | 1.3.2-r0 | **1.3.2-r0** |
| libpng | 1.6.55-r0 | 1.6.57-r0 | **1.6.58-r1** |
| libexpat | 2.7.4-r0 | 2.7.5-r0 | **2.7.5-r0** |
| libblkid / libmount | 2.41.2-r0 | 2.41.4-r0 | **2.41.4-r0** |
| imagemagick* | 7.1.2.15-r0 | 7.1.2.19-r0 | **7.1.2.24-r0** |
| rsync | 3.4.1-r1 | 3.4.1-r2 | **3.4.3-r0** |
| py3-cryptography | 46.0.5-r0 | 46.0.7-r0 | **46.0.7-r0** |

`docker build --check` passes with no warnings.

## Follow-up

After this merges and a new `appwrite/base` release is cut, bump `FROM appwrite/base:1.4.2` in `appwrite/appwrite` (`1.9.x`) to the new tag to clear the 315 downstream alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)