### PR TITLE
Pin docker-cli and compose to exact apk versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 1.4.5
+
+### Change
+
+* Pin `docker-cli` and `docker-cli-compose` apk packages to the exact versions already shipped in `1.4.4` (`29.5.2-r0` and `2.40.3-r6`) so Alpine package floats cannot silently bump the installer Docker client. Structure tests now assert those exact versions.
+
 ## Version 1.3.2
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,8 +221,8 @@ RUN apk update && \
     c-ares \
     certbot \
     freetype \
-    docker-cli \
-    docker-cli-compose \
+    docker-cli=29.5.2-r0 \
+    docker-cli-compose=2.40.3-r6 \
     git \
     icu-libs \
     imagemagick \

--- a/tests.yaml
+++ b/tests.yaml
@@ -16,11 +16,11 @@ commandTests:
   - name: 'Docker command'
     command: "docker"
     args: ["--version"]
-    expectedOutput: ["Docker version 29.*"]
+    expectedOutput: ["Docker version 29.5.2.*"]
   - name: 'Docker Compose command'
     command: "docker"
     args: ["compose", "version"]
-    expectedOutput: ["Docker Compose version v.*"]
+    expectedOutput: ["Docker Compose version v2.40.3"]
   - name: 'Git command'
     command: "git"
     args: ["--version"]


### PR DESCRIPTION
## Summary
- Pin `docker-cli=29.5.2-r0` and `docker-cli-compose=2.40.3-r6` in the final image (same versions already shipped in `1.4.4`)
- Tighten structure tests to assert those exact CLI/Compose versions
- Document in CHANGES as 1.4.5

This stops Alpine package floats from silently bumping the Docker client in future base builds. It does **not** downgrade the client; hosts on older Engine APIs (e.g. max 1.42) still need a separate compatibility approach.

## Test plan
- [ ] CI structure tests pass (`docker --version` / `docker compose version`)
- [ ] Confirm build fails clearly if Alpine drops these exact package versions from the 3.23 community repo


Made with [Cursor](https://cursor.com)