### PR TITLE
Publish the production image instead of the Xdebug variant

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -34,13 +34,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # --target is mandatory: the Dockerfile's last stage is the XDebug
+      # variant, so an untargeted build silently publishes XDebug as the
+      # production image.
       - name: Build an image from Dockerfile
         run: |
-          docker image build --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{matrix.arch}} .
+          docker image build --target final --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{matrix.arch}} .
+
+      - name: Build the XDebug variant
+        run: |
+          docker image build --target xdebug --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-${{matrix.arch}} .
 
       - name: Push an image
         run: |
           docker image push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-${{matrix.arch}}
+
+      - name: Push the XDebug variant
+        run: |
+          docker image push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-${{matrix.arch}}
 
   manifest_build_and_push_on_feature:
     if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
@@ -60,9 +71,20 @@ jobs:
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
 
+      - name: Create XDebug manifest
+        run: |
+            docker manifest create \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-arm64
+
       - name: Push manifest
         run: |
             docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Push XDebug manifest
+        run: |
+            docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug
 
   manifest_build_and_push_on_tag:
     if: startsWith(github.ref, 'refs/tags/')
@@ -82,6 +104,17 @@ jobs:
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
 
+      - name: Create XDebug manifest
+        run: |
+            docker manifest create \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-xdebug \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-amd64 \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug-arm64
+
       - name: Push manifest
         run: |
             docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+      - name: Push XDebug manifest
+        run: |
+            docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-xdebug

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker image build --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+          docker image build --target final --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
 
       - name: Dive
         uses: yuichielectric/dive-action@0.0.4

--- a/.github/workflows/structure-test.yml
+++ b/.github/workflows/structure-test.yml
@@ -19,10 +19,20 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker image build --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+          docker image build --target final --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+
+      - name: Build the XDebug variant
+        run: |
+          docker image build --target xdebug --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug .
 
       - name: Run container structure tests
         uses: plexsystems/container-structure-test-action@v0.1.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           config: tests.yaml
+
+      - name: Run container structure tests for the XDebug variant
+        uses: plexsystems/container-structure-test-action@v0.1.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug
+          config: tests-xdebug.yaml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker image build --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+          docker image build --target final --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner (sarif report)
         uses: aquasecurity/trivy-action@0.35.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## Version 1.4.5
+
+### Fix
+
+* Publish the production image instead of the XDebug variant. Every workflow built with `docker image build ... .` and no `--target`, and Docker defaults to the *last* stage — which is `xdebug`. So `appwrite/base` has shipped XDebug in the production image since the variant was introduced in 1.2.0, and Trivy and dive were measuring the wrong image too. All four build workflows now pass an explicit `--target`. The stage order cannot be fixed instead: `xdebug` is `FROM final`, so it must be declared after `final`, which necessarily makes it last — `--target` is the only reliable control.
+
+### Add
+
+* Publish the XDebug variant under `-xdebug` tags (`<sha>-xdebug`, `<tag>-xdebug`, per-arch and manifest). It was documented as a build target since 1.2.0 but never published, so consumers that want XDebug — such as Appwrite's `development` image, which supplies an ini expecting `xdebug.so` to already exist — now have a real image to pin.
+* Wire `tests-xdebug.yaml` into the structure-test workflow. It had existed since 1.2.0 with no workflow consuming it.
+* `tests.yaml` assertion that XDebug is absent. `tests.yaml` only ever asserted module *presence*, so the XDebug image satisfied it and CI stayed green while shipping the wrong image.
+
 ## Version 1.3.2
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ In order to run this container you'll need the Docker runtime installed.
 
 ## Build
 
+`--target` is required. The XDebug variant derives from `final`, so it has to be
+declared after it, which makes it the last stage — and Docker defaults to the
+last stage. Omitting `--target` therefore builds XDebug, not production.
+
 ```shell
 # Default (production) image
-docker build --no-cache --tag appwrite/base:latest .
+docker build --no-cache --target final --tag appwrite/base:latest .
 
 # XDebug variant
 docker build --no-cache --target xdebug --tag appwrite/base:latest-xdebug .

--- a/tests.yaml
+++ b/tests.yaml
@@ -78,6 +78,11 @@ commandTests:
       - yaml
       - zlib
       - zstd
+  - name: 'XDebug absent'
+    command: "php"
+    args: ["-m"]
+    excludedOutput:
+      - xdebug
   - name: 'PHP GD supported formats'
     command: "php"
     args: ["-i"]


### PR DESCRIPTION
## Problem

Every workflow builds with `docker image build ... .` and no `--target`. Docker defaults to the **last** stage, and the last stage is `xdebug`:

```
$ BUILDX_EXPERIMENTAL=1 docker buildx build --print=outline .
TARGET: xdebug
```

So every published `appwrite/base` image has shipped Xdebug since the variant was introduced in 1.2.0. Trivy and dive were also measuring that image rather than the one users actually run.

This is pre-existing on `main`, not introduced by the SHA-pinning work.

## Why not reorder the stages instead

`xdebug` is `FROM final`, so it must be declared after `final` — which necessarily makes it last. Forward stage references don't resolve; Docker reinterprets the name as an external image:

```
ERROR: failed to solve: final: failed to resolve source metadata for
docker.io/library/final:latest: pull access denied, repository does not exist
```

An explicit `--target` is the only reliable control, so the README now documents it as required for local builds too.

## Why CI never caught it

`tests.yaml` only ever asserted module *presence*. The Xdebug image satisfies every one of those assertions, so CI stayed green while shipping the wrong artifact. This PR adds an `excludedOutput` guard so the production image cannot silently regain Xdebug.

`tests-xdebug.yaml` has existed since 1.2.0 with no workflow consuming it; it is now wired into the structure-test workflow.

## Why the variant is published rather than dropped

Downstream consumers do depend on the base providing `xdebug.so`. Appwrite's `development` stage copies a `dev/xdebug.ini` containing `zend_extension=xdebug` but never installs the extension itself, while its `base`/`production` stages strip Xdebug back out — compensating for this bug from both directions.

Nothing tracks a floating tag (consumers pin `1.4.4`, `1.2.1`, `1.2.0`, `0.11.3`, `0.5.0`…), so this changes nothing retroactively. The variant is now published as `<sha>-xdebug` / `<tag>-xdebug` so those consumers have a real image to pin when they bump.

## Changes

- `--target final` in all four build workflows (`build-and-push`, `structure-test`, `dive`, `trivy`)
- Build and push the Xdebug variant under `-xdebug` tags, per-arch plus manifests
- Wire `tests-xdebug.yaml` into `structure-test.yml`
- `tests.yaml`: assert Xdebug is absent
- README: document `--target final` as required

## Verification

Both variants built locally on `arm64`:

| Build | `php -m` |
|---|---|
| `--target final` | no `xdebug`; all 56 expected modules present |
| `--target xdebug` | `xdebug` present |

## Follow-up (not in this PR)

`appwrite/appwrite` should point its `development` stage at `appwrite/base:<version>-xdebug` before bumping its pin, otherwise `--build-arg DEBUG=true` builds will fail to load the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)