### PR TITLE
(ci): pin the XDebug structure-test action by SHA

### DIFF
--- a/.github/workflows/structure-test.yml
+++ b/.github/workflows/structure-test.yml
@@ -32,7 +32,7 @@ jobs:
           config: tests.yaml
 
       - name: Run container structure tests for the XDebug variant
-        uses: plexsystems/container-structure-test-action@v0.1.0
+        uses: plexsystems/container-structure-test-action@c0a028aa96e8e82ae35be556040340cbb3e280ca # v0.3.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-xdebug
           config: tests-xdebug.yaml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ### Fix
 
 * Duplicate release builds — `build-and-push.yml` no longer triggers on `release: published`. Tag pushes already trigger it, so publishing a release rebuilt and repushed the same image a second time.
+* The XDebug `container-structure-test` step ran `plexsystems/container-structure-test-action@v0.1.0` — a mutable tag two minor versions behind the production step directly above it, and the only action reference in the repo not pinned to a commit SHA. Both steps now pin the same `v0.3.0` commit.
 
 ## Version 1.4.5
 


### PR DESCRIPTION
## Summary

`structure-test.yml` had one action reference left on a mutable tag:

```yaml
- name: Run container structure tests for the XDebug variant
  uses: plexsystems/container-structure-test-action@v0.1.0
```

Every other reference in the repo is a commit SHA with a trailing version comment — that convention was established in #79, and the XDebug step (added in #78) was missed. A mutable tag hands the action's owner write access to CI on every run, which is the exact thing the convention exists to prevent.

The step directly above it already pins the same action at `v0.3.0`, so the two steps in one job were running different versions of it.

Both now pin `c0a028aa96e8e82ae35be556040340cbb3e280ca # v0.3.0`.

## Verification

- `c0a028aa96e8e82ae35be556040340cbb3e280ca` resolved from upstream `refs/tags/v0.3.0` and dereferenced through the annotated tag object.
- Every other pin in `.github/workflows` re-resolved against upstream and confirmed to match its version comment: `actions/checkout` v7.0.1, `docker/login-action` v4.6.0, `aquasecurity/trivy-action` v0.36.0, `yuichielectric/dive-action` 0.0.4, `github/codeql-action/upload-sarif` v4.37.6.
- Zero unpinned `uses:` remain.

## Side effect

This supersedes Dependabot's #81, which exists only to bump this reference from 0.1.0 to 0.3.0.

## Not verified

Nothing outstanding. CI on this head confirms the XDebug step ran under the pinned `c0a028a` and passed `tests-xdebug.yaml`.

Unrelated, noted in passing: `tests-xdebug.yaml` contains a single assertion (`Total tests: 1`), so the XDebug variant's structure coverage is thin. Not addressed here.
