### PR TITLE
Fix vulnerabilities in latest base image

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,13 +33,16 @@ jobs:
       - name: Run Trivy vulnerability scanner (sarif report)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          exit-code: '1'
           format: 'sarif'
+          ignore-unfixed: true
           image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}'
           output: 'trivy-image-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL,HIGH,MEDIUM'
 
       # https://github.com/github/codeql-action/blob/main/upload-sarif/action.yml
       - name: Upload Trivy scan results
+        if: always()
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: '.'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Version 2.1.0
 
+### Security
+
+* Refresh the PHP 8.5 Alpine base image to PHP 8.5.10, pulling patched `libexpat` 2.8.4-r0 and `rsync` 3.5.0-r0 packages. The resulting production and XDebug images have no vulnerabilities reported by Trivy.
+* Make the Trivy workflow fail on fixable medium, high, or critical vulnerabilities while continuing to upload its SARIF report.
+
 ### Add
 
 * Weekly dependency automation (`.github/workflows/dependencies.yml`). A scheduled job resolves the newest upstream release for every pinned Dockerfile source, rewrites the pins, opens a pull request, waits for the exact CI runs for that head, approves and merges it, then tags, builds, and publishes the release. A `recover` step resumes a run that died between merge and publish, so a half-finished release is completed rather than duplicated.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pin php:8.5-alpine by multi-arch index digest. Bump with:
 #   docker buildx imagetools inspect php:8.5-alpine | head -2
-ARG BASE_IMAGE="php:8.5-alpine@sha256:0554eb53778b5316f6b9a3447c9dfa3cf2141c0c02ff816c42cdc9aa240a34aa"
+ARG BASE_IMAGE="php:8.5-alpine@sha256:763e2dc50d4b0cf8d02a1d8fbeedd43f9be879c0be928b1d6f247d45c81fa28f"
 
 FROM $BASE_IMAGE AS compile
 


### PR DESCRIPTION
## Summary
- refresh the pinned PHP 8.5 Alpine base to PHP 8.5.10
- pick up patched libexpat 2.8.4-r0 and rsync 3.5.0-r0 packages
- make Trivy block fixable medium, high, and critical vulnerabilities while always uploading SARIF

## Verification
- production image build passed
- XDebug image build passed
- Trivy: 37 findings in appwrite/base:2.0.2, 0 in both rebuilt images
- all production and XDebug container structure checks passed
- composer verify: 156 tests, 1,818 assertions; Pint, PHPStan, and parity passed
- composer validate --strict and composer check-platform-reqs passed