### PR TITLE
fix: require libcurl 8.22.0 for TLS shutdown cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ ENV \
     PHP_ZSTD_VERSION="0.18.0" \
     PHP_ZSTD_COMMIT="c2593a4ce2457b23e7fa7f81ddf0dd9bbdd89b47"
 
+# libcurl 8.22.0 fixes retained TLS shutdown sockets in the socket-action API
+# used by Swoole's curl hook (curl/curl#22282). Require it here and at runtime.
 RUN \
   apk update && \
   apk upgrade --no-cache && \
@@ -43,7 +45,7 @@ RUN \
     brotli-dev \
     c-ares-dev \
     curl \
-    curl-dev \
+    'curl-dev>=8.22.0' \
     g++ \
     gcc \
     git \
@@ -268,6 +270,7 @@ RUN apk update && \
     imagemagick \
     imagemagick-heic \
     libavif \
+    'libcurl>=8.22.0' \
     libgomp \
     libheif \
     libjpeg-turbo \

--- a/tests.yaml
+++ b/tests.yaml
@@ -1,6 +1,10 @@
 schemaVersion: '2.0.0'
 
 commandTests:
+  - name: 'PHP libcurl includes TLS shutdown fix'
+    command: "php"
+    args: ["-r", 'exit(version_compare(curl_version()["version"], "8.22.0", ">=") ? 0 : 1);']
+    exitCode: 0
   - name: 'Imagemagick command'
     command: "magick"
     args: ["--version"]


### PR DESCRIPTION
Require libcurl 8.22.0 in the build and runtime images. Version 8.21.0 can retain TLS shutdown connections when driven through the socket-action API used by Swoole's curl hook, causing socket and memory growth. Alpine 3.24 now ships the upstream fix, so no source backport is needed.

The container structure test checks PHP's loaded libcurl version and rejects the existing Cloud image (8.21.0).

Validation:
- All CI checks passed, including AMD64/ARM64 production and XDebug builds, structure tests, tooling verification, image efficiency, and security scan.
- All 16 structure tests passed locally against the exact CI-built ARM64 image.
- Loaded the production Cloud vendor tree and unchanged Span bootstrap onto that image: 2,400/2,400 synthetic Sentry events delivered, zero exporter errors. FDs started at 8, peaked at 26, and ended at 14 before destroying the client; 5 CLOSE_WAIT sockets remained at that sample, with no accumulating trend. Anonymous RSS ranged 17,996–18,504 KiB through the second half. The original 8.21.0 reproduction accumulated 400 CLOSE_WAIT sockets and 411 FDs after 400 events.
- Keep-alive: 400/400 delivered, zero exporter errors, one TCP connection.
- Docker build checks passed with no warnings. Local source builds encountered a PECL download timeout; behavioral validation used the CI-built image. An earlier soak run during compilation had seven connection timeouts and was not counted as passing; the completed-image run used the same timeout settings and passed.

This is a local transport regression test, not a production performance benchmark. No staging or production deployment is included in this PR.

Upstream: https://github.com/curl/curl/issues/22282 and https://github.com/curl/curl/commit/820c014578b56b9fa4d2c472e90b5060198dd404.
